### PR TITLE
Add script for Google Sheet Selenium logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@ src/data/characters.ts 設定人物角色、問題系列
 src/data/characters.ts 設定問題系列
 目前上線的是 git branch gh-pages
 請點選 https://playbaba.tw 開始遊戲
+
+## 自動化測試結果寫入 Google Sheet
+
+在 Colab 執行 Selenium 測試時，可使用 `scripts/selenium_to_gsheet.py`。此腳本會將測試產生的角色、回答組合、結果文字與圖片檔名寫入指定的 Google Sheet。
+
+1. 於 Colab 上傳 Google Service Account 的 `service_account.json` 憑證檔。
+2. 在 `scripts/selenium_to_gsheet.py` 內填入 `SPREADSHEET_ID` 及網址、元素選擇器等設定。
+3. 安裝必要套件：
+   ```python
+   !pip install selenium gspread oauth2client
+   ```
+4. 執行腳本即可將資料寫入工作表。
+5. 腳本會針對每個角色遍歷所有 `3^10` 組答案，將結果文字與圖片檔名逐行寫入 Google Sheet。
+

--- a/scripts/selenium_to_gsheet.py
+++ b/scripts/selenium_to_gsheet.py
@@ -1,0 +1,58 @@
+import time
+from itertools import product
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+import gspread
+
+
+def setup_gsheet(creds_path: str, spreadsheet_id: str):
+    """Authenticate and return the first worksheet."""
+    gc = gspread.service_account(filename=creds_path)
+    sh = gc.open_by_key(spreadsheet_id)
+    worksheet = sh.sheet1
+    worksheet.clear()
+    worksheet.append_row(['角色', '回答組合', '結果文字', '圖片檔名'])
+    return worksheet
+
+
+def run_test(driver: webdriver.Chrome, worksheet):
+    characters = driver.find_elements(By.CSS_SELECTOR, '.character')
+    for i, char in enumerate(characters):
+        char.click()
+        time.sleep(1)
+        for combo in product(range(3), repeat=10):
+            for q, ans_idx in enumerate(combo):
+                choices = driver.find_elements(By.CSS_SELECTOR, f'.question{q+1} .option')
+                choices[ans_idx].click()
+                time.sleep(0.3)
+            time.sleep(1)
+            text = driver.find_element(By.CSS_SELECTOR, '.result-text').text
+            img = driver.find_element(By.CSS_SELECTOR, '.result-image').get_attribute('src')
+            img_filename = img.split('/')[-1]
+            worksheet.append_row([f'角色{i+1}', ''.join(str(a + 1) for a in combo), text, img_filename])
+            driver.back()
+            time.sleep(1)
+            char.click()
+            time.sleep(1)
+        driver.back()
+        time.sleep(1)
+
+
+def main():
+    # Colab 可使用掛載的 credentials 與 spreadsheet id
+    CREDS_PATH = 'service_account.json'  # 在 Colab 上傳金鑰檔
+    SPREADSHEET_ID = 'YOUR_SPREADSHEET_ID'
+
+    worksheet = setup_gsheet(CREDS_PATH, SPREADSHEET_ID)
+
+    driver = webdriver.Chrome()
+    driver.maximize_window()
+    driver.get('https://example.com')  # 換成實際網址
+    time.sleep(2)
+
+    run_test(driver, worksheet)
+    driver.quit()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/selenium_to_gsheet.py` example
- document how to log Selenium results to Google Sheets
- test all answer combinations for each character

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685274b99bf083279b0bccbb6a153308